### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/betula_editor/src/ui.rs
+++ b/betula_editor/src/ui.rs
@@ -174,7 +174,7 @@ struct DefaultUiValueHandler<T: Chalkable + std::fmt::Debug> {
 }
 impl<T: Chalkable + std::fmt::Debug + Clone + 'static> UiValue for DefaultUiValueHandler<T> {
     fn ui(&mut self, ui: &mut Ui, _scale: f32) -> UiConfigResponse {
-        ui.label(format!("{:.?}", self.data));
+        ui.label(format!("{:?}", self.data));
         UiConfigResponse::UnChanged
     }
     fn value(&self) -> Box<dyn Chalkable> {


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.